### PR TITLE
An issue where the information for input connections would be printed on multiple lines has been fixed

### DIFF
--- a/trnsystor/trnsysmodel.py
+++ b/trnsystor/trnsysmodel.py
@@ -303,7 +303,7 @@ class TrnsysModel(Component):
         Returns:
             TrnsysModel: The TRNSYS model.
         """
-        name = kwargs.pop("name", tag.find("object").text)
+        name = kwargs.pop("name", tag.find("object").text).strip()
         meta = MetaData.from_tag(tag, **kwargs)
 
         model = cls(meta, name)


### PR DESCRIPTION
Before, an online plotter could print to deck like this:

```
UNIT 8 TYPE 65 Online graphical plotter with output file
*$UNIT_NAME Online graphical plotter with output file
*$MODEL tests\input_files\Type65c.xml
*$POSITION 50.0 50.0
*$LAYER Main
PARAMETERS 12
1      ! 1 Nb. of left-axis variables
2      ! 2 Nb. of right-axis variables
0      ! 3 Left axis minimum
30000  ! 4 Left axis maximum
0      ! 5 Right axis minimum
1000   ! 6 Right axis maximum
1      ! 7 Number of plots per simulation
12     ! 8 X-axis gridpoints
0      ! 9 Shut off Online w/o removing
30     ! 10 Logical Unit for output file
0      ! 11 Output file units
0      ! 12 Output file delimiter
INPUTS 3
7,14  ! Weather Data Processor; Combines data reading, radiation processing and sky temperature calculations
        :Global horizontal radiation (not interpolated) -> Online graphical plotter with output file:Left axis variable-1 
0,0   ! [unconnected] Online graphical plotter with output file:Right axis variable-1
0,0   ! [unconnected] Online graphical plotter with output file:Right axis variable-2
*** INITIAL INPUT VALUES
...
```

With, for example, Input 7,14 on 2 lines, preventing TRNSYS form properly parsing the file.