### PR TITLE
An issue printing an EquationCollection to deck has been fixed

### DIFF
--- a/trnsystor/collections/equation.py
+++ b/trnsystor/collections/equation.py
@@ -158,7 +158,7 @@ class EquationCollection(Component, collections.UserDict):
             position = "*$POSITION {} {}".format(
                 self.studio.position.x, self.studio.position.y
             )
-            unit_number = "*UNIT_NUMBER {}".format(self.unit_number)
+            unit_number = "*$UNIT_NUMBER {}".format(self.unit_number)
             return "\n" + "\n".join([unit_name, layer, position, unit_number]) + "\n"
 
         tail = _studio(self)


### PR DESCRIPTION
Fixes issue # 56

```python
>>> from trnsystor import *
>>> Equation.from_expression("flowRateDoubled  =  2*[1, 2]")
>>> eq = Equation.from_expression("flowRateDoubled  =  2*[1, 2]")
>>> eqc = EquationCollection(eq)
>>> print(eqc)
* EQUATIONS "None"
*
EQUATIONS 1
flowRateDoubled  =  2*[1, 2]
*$UNIT_NAME None
*$LAYER Main
*$POSITION 50.0 50.0
*$UNIT_NUMBER 1

```