### PR TITLE
Parsing a dck file now looks for xml proformas in the location specified in the file

### DIFF
--- a/trnsystor/deck.py
+++ b/trnsystor/deck.py
@@ -448,8 +448,11 @@ class Deck(object):
                     try:
                         component = TrnsysModel.from_xml(next(iter(xml)), name=n)
                     except StopIteration:
-                        raise ValueError(f"Could not find proforma for Type{t}")
-                    else:
+                        # could not find a proforma. Initializing component without
+                        # metadata in the hopes that we can parse the xml when key ==
+                        # "model" a couple lines further in the file.
+                        component = TrnsysModel(None, name=n)
+                    finally:
                         component._unit = int(u)
                         dck.update_models(component)
                 else:


### PR DESCRIPTION
When parsing a dck file, the Deck constructor will now look for proformas in the path specified by the `*$MODEL` attribute produced by TRNSYS Visual Studio (also produced by trnsystor) only if the `proforma_root` path is not specified.

Note that only xml format is supported at the moment. TMF is not.