### PR TITLE
Fix affine_transform matrix check and add NumPy test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 """Test utils module."""
 import pytest
 
-from trnsystor.utils import redistribute_vertices
+from trnsystor.utils import redistribute_vertices, affine_transform
 
 
 class TestRedistributeVertices:
@@ -39,3 +39,14 @@ class TestRedistributeVertices:
         new_goem = redistribute_vertices(zero_geom, 10)
         assert new_goem.length == 0
         assert new_goem == zero_geom
+
+
+def test_affine_transform_with_numpy_array():
+    """Ensure affine_transform accepts NumPy arrays without error."""
+    import numpy as np
+    from shapely.geometry import Point
+
+    geom = Point(1, 2)
+    matrix = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    result = affine_transform(geom, matrix)
+    assert result.equals(geom)

--- a/trnsystor/utils.py
+++ b/trnsystor/utils.py
@@ -29,7 +29,7 @@ def affine_transform(geom, matrix=None):
     import numpy as np
     from shapely.affinity import affine_transform
 
-    if not matrix:
+    if matrix is None:
         matrix = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 0]])
     matrix_l = matrix[0:2, 0:2].flatten().tolist() + matrix[0:2, 2].flatten().tolist()
     return affine_transform(geom, matrix_l)


### PR DESCRIPTION
## Summary
- use explicit `None` check for matrix in `affine_transform`
- add test exercising `affine_transform` with a NumPy array

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_b_689fd17db0f4832b815a3373252ca3c3