### PR TITLE
Refactor deck parser for thread-safe operation

### DIFF
--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,44 @@
+import concurrent.futures
+import textwrap
+
+from trnsystor.deck import Deck
+
+components_string = textwrap.dedent(
+    r"""
+    UNIT 3 TYPE  11 Tee Piece
+    *$UNIT_NAME Tee Piece
+    *$MODEL tests\input_files\Type11h.xml
+    *$POSITION 50.0 50.0
+    *$LAYER Main
+    PARAMETERS 1
+    1  ! 1 Tee piece mode
+    INPUTS 4
+    0,0  ! [unconnected] Tee Piece:Temperature at inlet 1
+    flowRateDoubled  ! double:flowRateDoubled -> Tee Piece:Flow rate at inlet 1
+    0,0  ! [unconnected] Tee Piece:Temperature at inlet 2
+    0,0  ! [unconnected] Tee Piece:Flow rate at inlet 2
+    *** INITIAL INPUT VALUES
+    20   ! Temperature at inlet 1
+    100  ! Flow rate at inlet 1
+    20   ! Temperature at inlet 2
+    100  ! Flow rate at inlet 2
+
+    * EQUATIONS "double"
+    *
+    EQUATIONS 1
+    flowRateDoubled  =  2*[1, 2]
+    *$UNIT_NAME double
+    *$LAYER Main
+    *$POSITION 50.0 50.0
+    *$UNIT_NUMBER 2
+    """
+)
+
+def _parse():
+    dck = Deck.loads(components_string, proforma_root="tests/input_files")
+    return len(dck.models)
+
+def test_load_is_thread_safe():
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+        results = list(ex.map(lambda _: _parse(), range(8)))
+    assert all(r == 2 for r in results)


### PR DESCRIPTION
## Summary
- Refactor `Deck._parse_string` to avoid module-level globals and document thread-safe design
- Handle empty user constants blocks without relying on globals
- Add concurrent parsing test to ensure reentrant behaviour

## Testing
- `pytest -q` *(fails: TestTrnsysModel::test_set_link_style, TestTrnsysModel::test_set_link_style_best, TestConstantsAndEquations::test_symbolic_expression, TestConstantsAndEquations::test_symbolic_expression_2)*
- `pytest tests/test_thread_safety.py::test_load_is_thread_safe -q`


------
https://chatgpt.com/codex/tasks/task_b_689fefb71148832b8a33ffd467efecf4