### PR TITLE
Fix tests and warnings

### DIFF
--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -65,7 +65,7 @@ class TestTrnsysModel:
         from trnsystor.trnsysmodel import TrnsysModel
 
         fan1 = TrnsysModel.from_xml("tests/input_files/Type107-simplified.xml")
-        return fan1
+        assert fan1 is not None
 
     def test_unit_name(self, pipe_type):
         assert pipe_type.unit_name == "Type951"
@@ -831,7 +831,6 @@ class TestDeck:
             dck = Deck.read_file(deck_file, proforma_root="tests/input_files")
             yield dck
 
-    @pytest.mark.xfail(raises=ValueError)
     @pytest.fixture(scope="class")
     def irregular_deck(self):
         from trnsystor.deck import Deck

--- a/trnsystor/canvas.py
+++ b/trnsystor/canvas.py
@@ -1,5 +1,6 @@
 """StudioCanvas module."""
 import networkx as nx
+from shapely.errors import GEOSException
 from shapely.geometry import LineString, box
 
 
@@ -80,5 +81,5 @@ class StudioCanvas:
         # create linestring and simplify to unit and return
         try:
             return LineString(shortest_path).simplify(1)
-        except ValueError:
+        except (ValueError, GEOSException):
             return shortest_path

--- a/trnsystor/linkstyle.py
+++ b/trnsystor/linkstyle.py
@@ -164,9 +164,16 @@ class LinkStyle(object):
             )
             + ":"
         )
-        path = ",".join(
-            [":".join(map(str, n.astype(int).tolist())) for n in np.array(self.path)]
-        )
+        raw_path = self.path
+        if raw_path is None:
+            coords = np.empty((0, 2))
+        elif hasattr(raw_path, "coords"):
+            coords = np.array(raw_path.coords)
+        else:
+            coords = np.array(raw_path)
+        if coords.ndim == 1:
+            coords = coords.reshape(1, -1)
+        path = ",".join([":".join(map(str, n.astype(int).tolist())) for n in coords])
         linestyle = str(_linestyle_to_studio(self.get_linestyle())) + ":"
         linewidth = str(self.get_linewidth()) + ":"
         connection_set = anchors + "1:" + color + linestyle + linewidth + "1:" + path

--- a/trnsystor/statement/equation.py
+++ b/trnsystor/statement/equation.py
@@ -151,9 +151,16 @@ class Equation(Statement, TypeVariable):
         Returns:
             Equation: The Equation Statement object.
         """
+        from sympy import Piecewise
         from sympy.parsing.sympy_parser import parse_expr
 
-        exp = parse_expr(exp)
+        def _lt(a, b):
+            return Piecewise((1, a < b), (0, True))
+
+        def _ge(a, b):
+            return Piecewise((1, a >= b), (0, True))
+
+        exp = parse_expr(exp, local_dict={"Lt": _lt, "Ge": _ge})
 
         if len(exp.free_symbols) != len(args):
             raise AttributeError(

--- a/trnsystor/trnsysmodel.py
+++ b/trnsystor/trnsysmodel.py
@@ -174,7 +174,7 @@ class MetaData(object):
         xml_file = Path(xml)
         with open(xml_file) as xml:
             soup = BeautifulSoup(xml, "xml")
-            my_objects = soup.findAll("TrnsysModel")
+            my_objects = soup.find_all("TrnsysModel")
             for trnsystype in my_objects:
                 kwargs.pop("name", None)
                 meta = cls.from_tag(trnsystype, **kwargs)
@@ -225,7 +225,7 @@ class TrnsysModel(Component):
         with open(xml_file) as xml:
             all_types = []
             soup = BeautifulSoup(xml, "xml")
-            my_objects = soup.findAll("TrnsysModel")
+            my_objects = soup.find_all("TrnsysModel")
             for trnsystype in my_objects:
                 t = cls._from_tag(trnsystype, **kwargs)
                 t._meta.model = xml_file

--- a/trnsystor/utils.py
+++ b/trnsystor/utils.py
@@ -11,7 +11,6 @@ if not hasattr(_Path, "getcwd"):
     _Path.getcwd = _Path.cwd
 from sympy import Expr, Symbol, cacheit
 from sympy.core.assumptions import StdFactKB
-from sympy.core.logic import fuzzy_bool
 from sympy.printing import StrPrinter
 
 
@@ -295,11 +294,13 @@ class TypeVariableSymbol(Symbol):
 
         tmp_asm_copy = assumptions.copy()
 
-        # be strict about commutativity
-        is_commutative = fuzzy_bool(assumptions.get("commutative", True))
-        assumptions["commutative"] = is_commutative
-        obj._assumptions = StdFactKB(assumptions)
+        assumptions_kb, assumptions_orig, assumptions0 = Symbol._canonical_assumptions(
+            **assumptions
+        )
+        obj._assumptions = assumptions_kb
         obj._assumptions._generator = tmp_asm_copy  # Issue #8873
+        obj._assumptions_orig = assumptions_orig
+        obj._assumptions0 = tuple(sorted(assumptions0.items()))
         return obj
 
     __xnew__ = staticmethod(__new_stage2__)  # never cached (e.g. dummy)


### PR DESCRIPTION
## Summary
- handle single-point connections by catching GEOS exceptions and stabilizing LinkStyle path serialization
- align TypeVariableSymbol with SymPy canonical assumptions and support conditional expressions in Equation.from_symbolic_expression
- replace deprecated BeautifulSoup `findAll` and clean up tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a05e41cdfc832ba854a780e964137d