### PR TITLE
Refactor parser to remove global state and add reentrancy test

### DIFF
--- a/tests/test_deck_parser.py
+++ b/tests/test_deck_parser.py
@@ -1,0 +1,22 @@
+from path import Path
+
+from trnsystor.deck import Deck
+from trnsystor.component import Component
+import itertools
+import networkx as nx
+
+
+def _parse_deck():
+    Component.INIT_UNIT_NUMBER = itertools.count(start=1)
+    Component.UNIT_GRAPH = nx.MultiDiGraph()
+    return Deck.read_file(
+        Path("tests/input_files/test_deck.dck"), proforma_root="tests/input_files"
+    )
+
+
+def test_parse_is_reentrant():
+    first = _parse_deck()
+    second = _parse_deck()
+    assert [type(m).__name__ for m in first.models] == [
+        type(m).__name__ for m in second.models
+    ]

--- a/trnsystor/deck.py
+++ b/trnsystor/deck.py
@@ -391,7 +391,8 @@ class Deck(object):
             proforma_root = Path.getcwd()
         else:
             proforma_root = Path(proforma_root)
-        global component, i
+
+        component = None
         while line:
             key, match = dck._parse_line(line)
             if key == "end":
@@ -470,9 +471,9 @@ class Deck(object):
                     list_eq.append(Equation.from_expression(value))
                 component = EquationCollection(list_eq, name=Name("block"))
             if key == "userconstantend":
-                try:
+                if component is not None:
                     dck.update_models(component)
-                except NameError:
+                else:
                     print("Empty UserConstants block")
             # read studio markup
             if key == "unitnumber":
@@ -535,13 +536,14 @@ class Deck(object):
                                 tvar_group = match.group("typevariable").strip()
                                 for j, tvar in enumerate(tvar_group.split(" ")):
                                     try:
+                                        tv_key = key
                                         if i >= init_at:
-                                            key = "initial_input_values"
+                                            tv_key = "initial_input_values"
                                             j = j + i - init_at
                                         else:
                                             j = i
                                         cls.set_typevariable(
-                                            dck, j, component, tvar, key
+                                            dck, j, component, tvar, tv_key
                                         )
                                     except (KeyError, IndexError, ValueError):
                                         continue


### PR DESCRIPTION
## Summary
- Refactor `Deck._parse_string` to avoid global `component`/`i`, using local variables and safe type-variable handling.
- Ensure user constants block handles missing components gracefully.
- Add regression test to confirm deck parsing is reentrant.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a065ea6eec832b93d42fea1f2a7159