### PR TITLE
Use on-demand canvas grid with configurable step size

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ specify parameters, connect components together and more throught python code.
 pip install trnsystor
 ```
 
+## Studio Canvas Grid
+
+Paths between component ports are routed on a logical grid.  The
+``StudioCanvas`` now exposes a configurable ``step`` parameter which controls
+the resolution of that grid.  Shortest paths are computed on-demand without
+building the full NetworkX grid graph, dramatically reducing memory usage for
+large canvases.
+
 ## Usage
 
 Since TRNSYS 18, type proformas can be exported to XML schemas. *trnsystor* builds on this

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,0 +1,29 @@
+import pytest
+from shapely.geometry import Point
+
+from trnsystor.canvas import StudioCanvas
+
+
+def test_shortest_path_uses_step():
+    canvas = StudioCanvas(width=20, height=10, step=10)
+    start = Point(0, 0)
+    end = Point(20, 0)
+    path = canvas.shortest_path(start, end, donotcross=False)
+    assert path is not None
+    assert list(path.coords) == [(0, 0), (10, 0), (20, 0)]
+
+
+def test_blocked_edges_prevent_reuse():
+    canvas = StudioCanvas(width=20, height=10, step=10)
+    start = Point(0, 0)
+    end = Point(20, 0)
+    first = canvas.shortest_path(start, end, donotcross=True)
+    assert first is not None
+    second = canvas.shortest_path(start, end, donotcross=True)
+    assert list(second.coords) == [
+        (0, 0),
+        (0, 10),
+        (10, 10),
+        (20, 10),
+        (20, 0),
+    ]

--- a/trnsystor/canvas.py
+++ b/trnsystor/canvas.py
@@ -1,5 +1,5 @@
 """StudioCanvas module."""
-import networkx as nx
+from collections import deque
 from shapely.errors import GEOSException
 from shapely.geometry import LineString, box
 
@@ -8,46 +8,34 @@ class StudioCanvas:
     """StudioCanvas class.
 
     Handles geometric positioning of Components on a grid.
+    The grid is represented implicitly and expanded on-demand when
+    searching for paths.  This avoids constructing a full NetworkX grid
+    graph which can easily reach millions of nodes for large canvases.
     """
 
-    def __init__(self, width=2000, height=1000):
+    def __init__(self, width=2000, height=1000, step=1):
         """Initialize object.
 
         Args:
             width (int): The width of the grid in points.
             height (int): The height of the grid in points.
+            step (int): Resolution of the grid in points.
         """
         self.width = width
         self.height = height
-
-        self._grid_valid = True
-        self._grid = None
+        self.step = step
+        # Keep track of edges that should not be crossed by subsequent
+        # paths.  Edges are stored as sorted tuples of coordinate pairs.
+        self._blocked_edges = set()
 
     @property
     def bbox(self):
         """Return a bounding box rectangle for the canvas."""
         return box(0, 0, self.width, self.height)
 
-    @property
-    def grid_is_valid(self):
-        """Return True if grid is valid."""
-        if self._grid_valid:
-            return True
-        else:
-            return False
-
-    @property
-    def grid(self):
-        """Return the two-dimensional grid graph of the studio canvas."""
-        if self.grid_is_valid and self._grid is not None:
-            return self._grid
-        else:
-            self._grid = nx.grid_2d_graph(self.width, self.height)
-            return self._grid
-
     def invalidate_grid(self):
-        """Invalidate grid."""
-        self._grid_valid = False
+        """Reset cached path information."""
+        self._blocked_edges.clear()
 
     def resize_canvas(self, width, height):
         """Change the canvas size.
@@ -62,24 +50,68 @@ class StudioCanvas:
         self.height = height
         self.invalidate_grid()
 
+    def _neighbors(self, node):
+        """Yield neighbouring nodes, honoring blocked edges."""
+        x, y = node
+        step = self.step
+        candidates = [
+            (x + step, y),
+            (x - step, y),
+            (x, y + step),
+            (x, y - step),
+        ]
+        for nx_, ny in candidates:
+            if 0 <= nx_ <= self.width and 0 <= ny <= self.height:
+                edge = tuple(sorted((node, (nx_, ny))))
+                if edge not in self._blocked_edges:
+                    yield (nx_, ny)
+
     def shortest_path(self, u, v, donotcross=True):
-        """Return shortest path between u and v on the :attr:`grid`.
+        """Return shortest path between ``u`` and ``v``.
+
+        The search is performed on-demand without constructing a full grid
+        graph.  Only nodes that are explored during the breadth-first
+        search are instantiated.
 
         Args:
             u (Point): The *from* Point geometry.
             v (Point): The *to* Point geometry.
-            dotnotcross (bool): If true, this path will not be crossed by other paths.
+            donotcross (bool): If true, this path will not be crossed by
+                other paths (edges are blocked for subsequent searches).
 
         Returns:
-            (LineString): The path from u to v along the studio graph
+            LineString: The path from ``u`` to ``v`` along the studio
+            graph or ``None`` if no path exists.
         """
-        shortest_path = nx.shortest_path(self.grid, (u.x, u.y), (v.x, v.y))
+        start = (u.x, u.y)
+        goal = (v.x, v.y)
+
+        queue = deque([start])
+        came_from = {start: None}
+        while queue:
+            current = queue.popleft()
+            if current == goal:
+                break
+            for nbr in self._neighbors(current):
+                if nbr not in came_from:
+                    queue.append(nbr)
+                    came_from[nbr] = current
+
+        if goal not in came_from:
+            return None
+
+        path = []
+        cur = goal
+        while cur is not None:
+            path.append(cur)
+            cur = came_from[cur]
+        path.reverse()
+
         if donotcross:
-            edges = self.grid.edges(shortest_path)
-            for edge in edges:
-                self.grid.remove_edges_from(edge)
-        # create linestring and simplify to unit and return
+            for edge in zip(path, path[1:]):
+                self._blocked_edges.add(tuple(sorted(edge)))
+
         try:
-            return LineString(shortest_path).simplify(1)
+            return LineString(path)
         except (ValueError, GEOSException):
-            return shortest_path
+            return path


### PR DESCRIPTION
## Summary
- replace eagerly-built NetworkX grid with implicit breadth-first search
- add `step` parameter to control grid resolution
- document and test the new StudioCanvas behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06d50b11c832bb177bfcd238b2f33