### PR TITLE
Refactor ControlCards to use dataclass for deterministic deck order

### DIFF
--- a/tests/test_controlcards_order.py
+++ b/tests/test_controlcards_order.py
@@ -1,0 +1,6 @@
+from trnsystor.controlcards import ControlCards
+
+
+def test_controlcards_deck_consistency():
+    outputs = {ControlCards.basic_template()._to_deck() for _ in range(5)}
+    assert len(outputs) == 1

--- a/tests/test_typevariable_predecessor.py
+++ b/tests/test_typevariable_predecessor.py
@@ -1,0 +1,15 @@
+import io
+from unittest.mock import patch
+
+from trnsystor.deck import Deck
+from trnsystor.component import Component
+
+
+def test_predecessor_missing_node_handled():
+    with patch("builtins.input", return_value="y"):
+        deck = Deck.read_file("tests/input_files/test_deck.dck", proforma_root="tests/input_files")
+    # remove a model node from the global UNIT_GRAPH
+    Component.UNIT_GRAPH.remove_node(deck.models[0])
+
+    # ensure saving the deck does not raise when a model is absent from UNIT_GRAPH
+    deck.to_file(io.StringIO(), None, "w")

--- a/trnsystor/controlcards.py
+++ b/trnsystor/controlcards.py
@@ -1,7 +1,8 @@
 """ControlCards module."""
+from dataclasses import dataclass, field, fields
+
 import tabulate
 
-from trnsystor.component import Component
 from trnsystor.statement import (
     DFQ,
     End,
@@ -22,114 +23,34 @@ from trnsystor.statement import (
 )
 
 
-class ControlCards(object):
-    """ControlCards class.
+@dataclass
+class ControlCards:
+    """Container for TRNSYS control and listing statements.
 
-    The :class:`ControlCards` is a container for all the TRNSYS Simulation
-    Control Statements and Listing Control Statements. It implements the
-    :func:`_to_deck` method which pretty-prints the statements with their
-    docstrings.
+    The order of the fields is significant since it defines the order in which
+    the statements are written to the deck. An ``END`` statement is always
+    appended at the end of the deck.
     """
 
-    def __init__(
-        self,
-        version=None,
-        simulation=None,
-        tolerances=None,
-        limits=None,
-        nancheck=None,
-        overwritecheck=None,
-        timereport=None,
-        dfq=None,
-        width=None,
-        nocheck=None,
-        eqsolver=None,
-        solver=None,
-        nolist=None,
-        list=None,
-        map=None,
-    ):
-        """Insure that each simulation has a SIMULATION and END statements.
+    version: Version | None = None
+    simulation: Simulation | None = None
+    tolerances: Tolerances | None = None
+    limits: Limits | None = None
+    nancheck: NaNCheck | None = None
+    overwritecheck: OverwriteCheck | None = None
+    timereport: TimeReport | None = None
+    dfq: DFQ | None = None
+    width: Width | None = None
+    nocheck: NoCheck | None = None
+    eqsolver: EqSolver | None = None
+    solver: Solver | None = None
 
-        The other simulation control statements are optional. Default values are assumed
-        for TOLERANCES, LIMITS, SOLVER, EQSOLVER and DFQ if they are not present
+    # Listing Control Statements
+    nolist: NoList | None = None
+    list: List | None = None
+    map: Map | None = None
 
-        Args:
-            version (Version): The VERSION Statement. labels the deck with the
-                TRNSYS version number. See :class:`Version` for more details.
-            simulation (Simulation): The SIMULATION Statement.determines the
-                starting and stopping times of the simulation as well as the
-                time step to be used. See :class:`Simulation` for more details.
-            tolerances (Tolerances, optional): Convergence Tolerances (
-                TOLERANCES). Specifies the error tolerances to be used during a
-                TRNSYS simulation. See :class:`Tolerances` for more details.
-            limits (Limits, optional): The LIMITS Statement. Sets limits on the
-                number of iterations that will be performed by TRNSYS during a
-                time step before it is determined that the differential
-                equations and/or algebraic equations are not converging. See
-                :class:`Limits` for more details.
-            nancheck (NaNCheck, optional): The NAN_CHECK Statement. An optional
-                debugging feature in TRNSYS. If the NAN_CHECK statement is
-                present, then the TRNSYS kernel checks every output of each
-                component at each iteration and generates a clean error if ever
-                one of those outputs has been set to the FORTRAN NaN condition.
-                See :class:`NaNCheck` for more details.
-            overwritecheck (OverwriteCheck, optional): The OVERWRITE_CHECK
-                Statement. An optional debugging feature in TRNSYS. Checks to
-                make sure that each Type did not write outside its allotted
-                space. See :class:`OverwriteCheck` for more details.
-            timereport (TimeReport, optional): The TIME_REPORT Statement. Turns
-                on or off the internal calculation of the time spent on each
-                unit. See :class:`TimeReport` for more details.
-            dfq (DFQ, optional): Allows the user to select one of three
-                algorithms built into TRNSYS to numerically solve differential
-                equations. See :class:`DFQ` for more details.
-            width (Width, optional): Set the number of characters to be allowed
-                on a line of TRNSYS output. See :class:`Width` for more details.
-            nocheck (NoCheck, optional): The Convergence Check Suppression
-                Statement. Remove up to 20 inputs for the convergence check. See
-                :class:`NoCheck` for more details.
-            eqsolver (EqSolver, optional): The Equation Solving Method
-                Statement. The order in which blocks of EQUATIONS are solved is
-                controlled by the EQSOLVER Statement. See :class:`EqSolver` for
-                more details.
-            solver (Solver, optional): The SOLVER Statement. Select the
-                computational scheme. See :class:`Solver` for more details.
-            nolist (NoList, optional): The NOLIST Statement. See :class:`NoList`
-                for more details.
-            list (List, optional): The LIST Statement. See :class:`List` for
-                more details.
-            map (Map, optional): The MAP Statement. See :class:`Map` for more
-                details.
-
-        Note:
-            Some Statements have not been implemented because only TRNSYS gods 😇
-            use them. Here is a list of Statements that have been ignored:
-
-            - The Convergence Promotion Statement (ACCELERATE)
-            - The Calling Order Specification Statement (LOOP)
-        """
-        super().__init__()
-        self.version = version
-        self.simulation = simulation
-
-        self.tolerances = tolerances
-        self.limits = limits
-        self.nancheck = nancheck
-        self.overwritecheck = overwritecheck
-        self.timereport = timereport
-
-        self.dfq = dfq
-        self.nocheck = nocheck
-        self.eqsolver = eqsolver
-        self.solver = solver
-
-        # Listing Control Statements
-        self.nolist = nolist
-        self.list = list
-        self.map = map
-
-        self.end = End()
+    end: End = field(default_factory=End, init=False)
 
     def __str__(self):
         """Return str(self)."""
@@ -193,15 +114,14 @@ class ControlCards(object):
         version = str(self.version) + "\n"
         head = "*** Control Cards\n"
         v_ = []
-        for param in self.__dict__.values():
-            if isinstance(param, Version):
+        for field_ in fields(self):
+            param = getattr(self, field_.name, None)
+            if isinstance(param, Version) or param is None:
                 continue
-            if isinstance(param, Component):
-                v_.append((str(param), None))
             if hasattr(param, "doc"):
-                v_.append((str(param), "! {}".format(param.doc)))
+                v_.append((str(param), f"! {param.doc}"))
             else:
-                pass
+                v_.append((str(param), None))
         statements = tabulate.tabulate(tuple(v_), tablefmt="plain", numalign="left")
         return version + head + statements
 

--- a/trnsystor/typevariable.py
+++ b/trnsystor/typevariable.py
@@ -190,6 +190,8 @@ class TypeVariable(object):
         """
         if len(self.model.UNIT_GRAPH) == 0:
             return None
+        if self.model not in self.model.UNIT_GRAPH:
+            return None
         predecessors = []
         for pre in self.model.UNIT_GRAPH.predecessors(self.model):
             for key in self.model.UNIT_GRAPH[pre][self.model]:


### PR DESCRIPTION
## Summary
- convert ControlCards to a dataclass with ordered fields and default END
- iterate over dataclass fields when generating deck output
- add regression test ensuring ControlCards deck output is stable across runs
- handle missing graph nodes when resolving TypeVariable predecessors to avoid NetworkX errors
- add regression test confirming Deck saving succeeds with absent graph nodes

## Testing
- `pytest tests/test_controlcards_order.py tests/test_typevariable_predecessor.py tests/test_xml.py::TestDeck::test_save -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06d6a6620832bba02d65ece856d5a