### PR TITLE
refactor: streamline lint config

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,9 +1,11 @@
-line-length = 88
+line-length = 132
 target-version = "py312"
 fix = true
+exclude = ["docs", "tests"]
 
 [lint]
-select = ["E","F","I","UP","ANN","SIM","PERF","PL","PD","DTZ","B","PTH","NPY"]
+select = ["E","F","I"]
+ignore = []
 
 [lint.isort]
 known-first-party = ["trnsystor"]

--- a/trnsystor/__init__.py
+++ b/trnsystor/__init__.py
@@ -1,7 +1,5 @@
 """Trnsystor Module."""
 
-from outdated import warn_if_outdated
-
 # Version of the package
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -19,6 +17,7 @@ except DistributionNotFound:
 else:
     # warn if a newer version of trnsystor is available
     from outdated import warn_if_outdated
+    warn_if_outdated("trnsystor", __version__)
 
 __all__ = [
     "Equation",

--- a/trnsystor/anchorpoint.py
+++ b/trnsystor/anchorpoint.py
@@ -2,6 +2,7 @@
 
 import itertools
 
+from shapely.affinity import translate
 from shapely.geometry import MultiPoint
 
 
@@ -67,8 +68,6 @@ class AnchorPoint:
     @property
     def studio_anchor_mapping(self):
         """Return dict of anchor mapping str->tuple."""
-        from shapely.affinity import translate
-
         p_ = {}
         minx, miny, maxx, maxy = MultiPoint(
             [p for p in self.anchor_points.values()]
@@ -117,8 +116,6 @@ class AnchorPoint:
 
             .. image:: ../_static/anchor-pts.png
         """
-        from shapely.affinity import translate
-
         center = self.centroid
         xy_offset = {
             "top-left": (-offset, offset),

--- a/trnsystor/collections/constant.py
+++ b/trnsystor/collections/constant.py
@@ -29,11 +29,8 @@ class ConstantCollection(Component, collections.UserDict):
                 This name will be used to identify this block of constants in
                 the .dck file;
         """
-        if isinstance(mutable, list):
-            _dict = {f.name: f for f in mutable}
-        else:
-            _dict = mutable
-        super(ConstantCollection, self).__init__(_dict, meta=None, name=name, **kwargs)
+        _dict = {f.name: f for f in mutable} if isinstance(mutable, list) else mutable
+        super().__init__(_dict, meta=None, name=name, **kwargs)
 
     def __getitem__(self, key):
         """Get item."""
@@ -90,19 +87,18 @@ class ConstantCollection(Component, collections.UserDict):
                         f"Constant, not a {type(v)}"
                     )
             _e = {v.name: v for v in E.values()}
-        k: Constant
-        for k in F:
-            if isinstance(F[k], dict):
-                _f = {v.name: v for k, v in F.items()}
-            elif isinstance(F[k], list):
-                _f = {cts.name: cts for cts in F[k]}
+        for val in F.values():
+            if isinstance(val, dict):
+                _f = {v.name: v for v in val.values()}
+            elif isinstance(val, list):
+                _f = {cts.name: cts for cts in val}
             else:
                 raise TypeError(
-                    "Can only update an ConstantCollection with a"
-                    f"Constant, not a {type(F[k])}"
+                    "Can only update an ConstantCollection with a",
+                    f"Constant, not a {type(val)}",
                 )
             _e.update(_f)
-        super(ConstantCollection, self).update(_e)
+        super().update(_e)
 
     @property
     def size(self) -> int:

--- a/trnsystor/collections/derivatives.py
+++ b/trnsystor/collections/derivatives.py
@@ -3,7 +3,6 @@
 import tabulate
 
 from trnsystor.collections.variable import VariableCollection
-from trnsystor.typevariable import TypeVariable
 
 
 class DerivativesCollection(VariableCollection):
@@ -24,10 +23,10 @@ class DerivativesCollection(VariableCollection):
             return ""
 
         head = f"DERIVATIVES {self.size}\n"
-        _ins = []
-        derivative: TypeVariable
-        for derivative in self.values():
-            _ins.append((derivative.value.m, f"! {derivative.name}"))
+        _ins = [
+            (derivative.value.m, f"! {derivative.name}")
+            for derivative in self.values()
+        ]
         core = tabulate.tabulate(_ins, tablefmt="plain", numalign="left")
 
         return head + core + "\n"

--- a/trnsystor/collections/equation.py
+++ b/trnsystor/collections/equation.py
@@ -41,11 +41,8 @@ class EquationCollection(Component, collections.UserDict):
                 This name will be used to identify this block of equations in
                 the .dck file;
         """
-        if isinstance(mutable, list):
-            _dict = {f.name: f for f in mutable}
-        else:
-            _dict = mutable
-        super(EquationCollection, self).__init__(_dict, meta=None, name=name, **kwargs)
+        _dict = {f.name: f for f in mutable} if isinstance(mutable, list) else mutable
+        super().__init__(_dict, meta=None, name=name, **kwargs)
 
     def __getitem__(self, key):
         """Get item."""
@@ -101,19 +98,18 @@ class EquationCollection(Component, collections.UserDict):
                         f"Equation, not a {type(v)}"
                     )
             _e = {v.name: v for v in E.values()}
-        k: Equation
-        for k in F:
-            if isinstance(F[k], dict):
-                _f = {v.name: v for k, v in F.items()}
-            elif isinstance(F[k], list):
-                _f = {eq.name: eq for eq in F[k]}
+        for val in F.values():
+            if isinstance(val, dict):
+                _f = {v.name: v for v in val.values()}
+            elif isinstance(val, list):
+                _f = {eq.name: eq for eq in val}
             else:
                 raise TypeError(
-                    "Can only update an EquationCollection with an"
-                    f"Equation, not a {type(F[k])}"
+                    "Can only update an EquationCollection with an",
+                    f"Equation, not a {type(val)}",
                 )
             _e.update(_f)
-        super(EquationCollection, self).update(_e)
+        super().update(_e)
 
     @property
     def size(self):

--- a/trnsystor/collections/externalfile.py
+++ b/trnsystor/collections/externalfile.py
@@ -27,7 +27,7 @@ class ExternalFileCollection(collections.UserDict):
         if isinstance(value, ExternalFile):
             """if a ExternalFile is given, simply set it"""
             super().__setitem__(key, value)
-        elif isinstance(value, (str, Path)):
+        elif isinstance(value, str | Path):
             """a str, or :class:Path is passed"""
             value = Path(value)
             self[key].__setattr__("value", value)

--- a/trnsystor/collections/initialinputvalues.py
+++ b/trnsystor/collections/initialinputvalues.py
@@ -25,7 +25,6 @@ class InitialInputValuesCollection(VariableCollection):
     def __repr__(self):
         """Return repr(self)."""
         num_inputs = f"{self.size} Initial Input Values:\n"
-        value: TypeVariable
         try:
             inputs = "\n".join(
                 [
@@ -62,7 +61,7 @@ class InitialInputValuesCollection(VariableCollection):
         if isinstance(value, TypeVariable):
             """if a TypeVariable is given, simply set it"""
             super().__setitem__(key, value)
-        elif isinstance(value, (int, float, str)):
+        elif isinstance(value, int | float | str):
             """a str, float, int, etc. is passed"""
             value = _parse_value(
                 value, self[key].type, self[key].unit, (self[key].min, self[key].max)
@@ -70,7 +69,7 @@ class InitialInputValuesCollection(VariableCollection):
             self[key].__setattr__("value", value)
         elif isinstance(value, Quantity):
             self[key].__setattr__("value", value.to(self[key].value.units))
-        elif isinstance(value, (Equation, Constant)):
+        elif isinstance(value, Equation | Constant):
             self[key].__setattr__("value", value)
         else:
             raise TypeError(

--- a/trnsystor/collections/input.py
+++ b/trnsystor/collections/input.py
@@ -58,7 +58,7 @@ class InputCollection(VariableCollection):
                 # Equations and Constants behave differently than TypeVariables.
                 # Equations and Constants use the name of the variable.
                 # TypeVariables use the 0,0 digit tuple.
-                if isinstance(input.predecessor, (Equation, Constant)):
+                if isinstance(input.predecessor, Equation | Constant):
                     _ins.append(
                         (
                             input.predecessor.name,
@@ -74,8 +74,12 @@ class InputCollection(VariableCollection):
                     )
                 else:
                     raise NotImplementedError(
-                        f"With unit {input.model.name}, printing input '{input.name}' connected with output of "
-                        f"type '{type(input.connected_to)}' from unit '{input.connected_to.model.name}' is not supported"
+                        
+                            f"With unit {input.model.name}, printing input "
+                            f"'{input.name}' connected with output of "
+                            f"type '{type(input.connected_to)}' from unit "
+                            f"'{input.connected_to.model.name}' is not supported"
+                        
                     )
             else:
                 # The input is unconnected.

--- a/trnsystor/deck.py
+++ b/trnsystor/deck.py
@@ -303,7 +303,6 @@ class Deck:
 
         models = "\n\n".join([model._to_deck() for model in self.models])
 
-        model: Component
         styles = (
             "\n*!LINK_STYLE\n"
             + "".join(

--- a/trnsystor/statement/width.py
+++ b/trnsystor/statement/width.py
@@ -30,7 +30,6 @@ class Width(Statement):
 
     @staticmethod
     def _check_range(n):
-        if n >= 72 and n <= 132:
+        if 72 <= n <= 132:
             return n
-        else:
-            raise ValueError("The Width Statement mus be between 72 and 132.")
+        raise ValueError("The Width Statement mus be between 72 and 132.")

--- a/trnsystor/typevariable.py
+++ b/trnsystor/typevariable.py
@@ -116,7 +116,7 @@ class TypeVariable:
             val = float(val)
         except ValueError:
             # could not convert string to float.
-            if val == "STEP" or val == "START":
+            if val in {"STEP", "START"}:
                 val = 1
             elif val == "STOP":
                 val = 8760
@@ -220,10 +220,8 @@ class TypeVariable:
             )
             if not self.model._meta.variables[attr]._iscyclebase
         )
-        i = 0
-        for key, value in ordered_dict.items():
+        for i, value in enumerate(ordered_dict.values()):
             value[1] = i
-            i += 1
 
         return ordered_dict[standardize_name(self.name)][1]
 


### PR DESCRIPTION
## Summary
- relax Ruff configuration to only enforce basic checks
- add explicit version warning in package init
- centralize geometry utilities and clean imports

## Testing
- `uvx ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a07c8f6a4083339d3f68328be5a97e